### PR TITLE
Fix message reponding

### DIFF
--- a/dark-facebook-messenger-theme.user.css
+++ b/dark-facebook-messenger-theme.user.css
@@ -192,6 +192,22 @@
         fill: var(--normal-dark-red);
     }
 
+    /* Message response */
+    /* Box sorrounding the text of response to message */
+    div._8lma > ._3egs {
+        background-color: var(--dark-gray);
+    }
+
+    /* Line with text for responding to message */
+    ._3egs > ._4k7a {
+        color: var(--normal-dark-red);
+    }
+
+    /* Quoted message that is responded to */
+    ._4k7e > span > span {
+        color: var(--dark-gray);
+    }
+
     /* React to message */
     ._5zvq._7i2o > svg > g > path {
         fill: var(--normal-dark-red);


### PR DESCRIPTION
Styling for fixing message responding.
Fixes #13 

## Example image
Response to a message:
![image](https://user-images.githubusercontent.com/14054353/75390155-0e12ee00-58e8-11ea-8dd9-53c80fd8a65c.png)
